### PR TITLE
Release v1.0.0

### DIFF
--- a/changes/+develop.housekeeping
+++ b/changes/+develop.housekeeping
@@ -1,1 +1,0 @@
-Rebaked from the cookie `develop`.

--- a/changes/1.added
+++ b/changes/1.added
@@ -1,1 +1,0 @@
-Forked project and updated to work with Nautobot.

--- a/docs/admin/release_notes/version_1.0.md
+++ b/docs/admin/release_notes/version_1.0.md
@@ -1,48 +1,18 @@
+
 # v1.0 Release Notes
-
-!!! warning "Developer Note - Remove Me!"
-    Guiding Principles:
-
-    - Changelogs are for humans, not machines.
-    - There should be an entry for every single version.
-    - The same types of changes should be grouped.
-    - Versions and sections should be linkable.
-    - The latest version comes first.
-    - The release date of each version is displayed.
-    - Mention whether you follow Semantic Versioning.
-
-    Types of changes:
-
-    - `Added` for new features.
-    - `Changed` for changes in existing functionality.
-    - `Deprecated` for soon-to-be removed features.
-    - `Removed` for now removed features.
-    - `Fixed` for any bug fixes.
-    - `Security` in case of vulnerabilities.
-
 
 This document describes all new features and changes in the release `1.0`. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Release Overview
 
-- Major features or milestones
-- Achieved in this `x.y` release
-- Changes to compatibility with Nautobot and/or other apps, libraries etc.
+We are thrilled to ship Nautobot Topology Views 1.0—the first stable release of an app that turns your live inventory into clear, interactive topology diagrams inside Nautobot. This milestone caps a ground-up migration from the original NetBox-oriented codebase: every integration point was revalidated for Nautobot so you get the same powerful visualization workflow on a platform built for network automation at scale. If you have been waiting for first-class topology in Nautobot, this is the release to install and explore.
 
-## [v1.0.1] - 2021-09-08
+## [v1.0.0 (2026-03-25)](https://github.com/nautobot/nautobot-app-topology-views/releases/tag/v1.0.0)
 
 ### Added
 
-### Changed
+- [#1](https://github.com/nautobot/nautobot-app-topology-views/issues/1) - Forked project and updated to work with Nautobot.
 
-### Fixed
+### Housekeeping
 
-- [#123](https://github.com/nautobot/nautobot-app-topology-views/issues/123) Fixed Tag filtering not working in job launch form
-
-## [v1.0.0] - 2021-08-03
-
-### Added
-
-### Changed
-
-### Fixed
+- Rebaked from the cookie `develop`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nautobot-topology-views"
-version = "0.1.0"
+version = "1.0.0"
 description = "Nautobot App that draws network topology diagrams"
 authors = ["Justin Drew <info@networktocode.com>"]
 license = "Apache-2.0"
@@ -163,7 +163,7 @@ build-backend = "poetry.core.masonry.api"
 [tool.towncrier]
 package = "nautobot_topology_views"
 directory = "changes"
-filename = "docs/admin/release_notes/version_X.Y.md"
+filename = "docs/admin/release_notes/version_1.0.md"
 template = "development/towncrier_template.j2"
 start_string = "<!-- towncrier release notes start -->"
 issue_format = "[#{issue}](https://github.com/nautobot/nautobot-app-topology-views/issues/{issue})"


### PR DESCRIPTION
Summary
Ships Nautobot Topology Views 1.0 on main: first stable release line, updated release notes, and version metadata aligned with the launch.

What’s in this merge
Version — Bumps the package to 1.0.0 in pyproject.toml.
Release notes — Refreshes docs/admin/release_notes/version_1.0.md with a proper v1.0.0 section (2026-03-25), removes the old cookiecutter “developer note” boilerplate, and adds a short Release Overview that frames 1.0 as the milestone where topology visualization is fully at home in Nautobot after the NetBox-oriented codebase was migrated and revalidated end-to-end.
Towncrier — Points [tool.towncrier].filename at docs/admin/release_notes/version_1.0.md so future changelog builds target the 1.0 doc.
Changelog fragments — Removes the consumed fragments (changes/1.added, changes/+develop.housekeeping) now reflected in the published release notes.
Why merge now
This aligns main with the 1.0.0 tag and documentation story users should see from the default branch, and completes the housekeeping from the develop release-prep work.

